### PR TITLE
Joel.williams/feature/observer models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 **.un~
 **.swp
 .DS_Store
+cd j

--- a/joel.williams/observer/app/models/lamp.rb
+++ b/joel.williams/observer/app/models/lamp.rb
@@ -1,0 +1,9 @@
+class Lamp < ApplicationRecord
+  attr_accessor :on, :type
+
+  def update(type, id)
+    subject = type.find(id)
+    self.on = subject.on
+  end
+  
+end

--- a/joel.williams/observer/app/models/lamp.rb
+++ b/joel.williams/observer/app/models/lamp.rb
@@ -1,9 +1,21 @@
 class Lamp < ApplicationRecord
   attr_accessor :on, :type
 
+   # TODO: dupe code - move to helper
+   def convert_to_model(modelName)
+    case modelName
+    when "Lamp"
+      Lamp
+    when "Switch"
+      Switch
+    else
+      "Error 404: no model found by name #{modelName}"
+    end
+  end
+
   def update(type, id)
-    subject = type.find(id)
+    subject = self.convert_to_model(type).find(id)
     self.on = subject.on
   end
-  
+
 end

--- a/joel.williams/observer/app/models/subscription.rb
+++ b/joel.williams/observer/app/models/subscription.rb
@@ -1,0 +1,2 @@
+class Subscription < ApplicationRecord
+end

--- a/joel.williams/observer/app/models/switch.rb
+++ b/joel.williams/observer/app/models/switch.rb
@@ -2,36 +2,51 @@ class Switch < ApplicationRecord
   attr_accessor :on, :type
 
   def plug_in(observerType, observerId)
-    self.attach(observerType, observerId)
+    attach(observerType, observerId)
   end
 
   def unplug(observerType, observerId)
-    self.detach(observerType, observerId)
+    detach(observerType, observerId)
   end
 
 
   def flip
-    self.on = !on 
-    self.notify()
+    # TODO: add Pry and check here to see why ON isn't changing value
+    self.on = !on
+    notify()
   end
-  
+
+  # TODO: dupe code - move to helper
+  def convert_to_model(modelName)
+    case modelName
+    when "Lamp"
+      Lamp
+    when "Switch"
+      Switch
+    else
+      "Error 404: no model found by name #{modelName}"
+    end
+  end
+
   # these methods belong to a Subject
-  private
-  
-  def attach(observerType, observerId)
-    subscription = Subscription.create(observerType: observerType, observerId: observerId, subjectType: self.type, subjectId: self.id)
-  end
+  # private
+    
+  # TODO: Migration defaults are only soft-set.
+  # shows in full instance object but not when calling X.on or X.type
+    def attach(observerType, observerId)
+      subscription = Subscription.create(observerType: observerType, observerId: observerId, subjectType: self.type, subjectId: self.id)
+    end
 
-  def detach(observerType, observerId)
-    subscription = Subscription.find_by(observerType: observerType, observerId: observerId)
-    Subscription.destroy(subscription.id)
-  end
+    def detach(observerType, observerId)
+      subscription = Subscription.find_by(observerType: observerType, observerId: observerId)
+      Subscription.destroy(subscription.id)
+    end
 
-  def notify()
-    Subscription.all.each do | sub |
-      sub.observerType
-      .find_by(id: sub.observerId)
-      .update(self.type, self.id)
+    def notify()
+      Subscription.all.each do | sub |
+        self.convert_to_model(sub.observerType).find_by(id: sub.observerId).update(self.type, self.id)
+    end
+
   end
   
 end

--- a/joel.williams/observer/app/models/switch.rb
+++ b/joel.williams/observer/app/models/switch.rb
@@ -1,0 +1,37 @@
+class Switch < ApplicationRecord
+  attr_accessor :on, :type
+
+  def plug_in(observerType, observerId)
+    self.attach(observerType, observerId)
+  end
+
+  def unplug(observerType, observerId)
+    self.detach(observerType, observerId)
+  end
+
+
+  def flip
+    self.on = !on 
+    self.notify()
+  end
+  
+  # these methods belong to a Subject
+  private
+  
+  def attach(observerType, observerId)
+    subscription = Subscription.create(observerType: observerType, observerId: observerId, subjectType: self.type, subjectId: self.id)
+  end
+
+  def detach(observerType, observerId)
+    subscription = Subscription.find_by(observerType: observerType, observerId: observerId)
+    Subscription.destroy(subscription.id)
+  end
+
+  def notify()
+    Subscription.all.each do | sub |
+      sub.observerType
+      .find_by(id: sub.observerId)
+      .update(self.type, self.id)
+  end
+  
+end

--- a/joel.williams/observer/db/migrate/20200905030308_create_lamps.rb
+++ b/joel.williams/observer/db/migrate/20200905030308_create_lamps.rb
@@ -2,7 +2,8 @@ class CreateLamps < ActiveRecord::Migration[5.2]
   def change
     create_table :lamps do |t|
       t.boolean :on, default: false
-
+      t.string :type, default: "Lamp"
+      
       t.timestamps
     end
   end

--- a/joel.williams/observer/db/migrate/20200905030308_create_lamps.rb
+++ b/joel.williams/observer/db/migrate/20200905030308_create_lamps.rb
@@ -1,0 +1,9 @@
+class CreateLamps < ActiveRecord::Migration[5.2]
+  def change
+    create_table :lamps do |t|
+      t.boolean :on, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/joel.williams/observer/db/migrate/20200905030356_create_switches.rb
+++ b/joel.williams/observer/db/migrate/20200905030356_create_switches.rb
@@ -1,0 +1,10 @@
+class CreateSwitches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :switches do |t|
+      t.boolean :on, default: false
+      t.string :type, default: "Switch"
+
+      t.timestamps
+    end
+  end
+end

--- a/joel.williams/observer/db/migrate/20200905030449_create_subscriptions.rb
+++ b/joel.williams/observer/db/migrate/20200905030449_create_subscriptions.rb
@@ -1,0 +1,12 @@
+class CreateSubscriptions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :subscriptions do |t|
+      t.string :observerType
+      t.integer :observerId
+      t.sstring :subjectType
+      t.integer :subsjectId
+
+      t.timestamps
+    end
+  end
+end

--- a/joel.williams/observer/db/migrate/20200905030449_create_subscriptions.rb
+++ b/joel.williams/observer/db/migrate/20200905030449_create_subscriptions.rb
@@ -3,8 +3,8 @@ class CreateSubscriptions < ActiveRecord::Migration[5.2]
     create_table :subscriptions do |t|
       t.string :observerType
       t.integer :observerId
-      t.sstring :subjectType
-      t.integer :subsjectId
+      t.string :subjectType
+      t.integer :subjectId
 
       t.timestamps
     end

--- a/joel.williams/observer/db/schema.rb
+++ b/joel.williams/observer/db/schema.rb
@@ -1,0 +1,40 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_09_05_030449) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "lamps", force: :cascade do |t|
+    t.boolean "on", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "subscriptions", force: :cascade do |t|
+    t.string "observerType"
+    t.integer "observerId"
+    t.string "subjectType"
+    t.integer "subjectId"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "switches", force: :cascade do |t|
+    t.boolean "on", default: false
+    t.string "type", default: "Switch"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/joel.williams/observer/test/fixtures/lamps.yml
+++ b/joel.williams/observer/test/fixtures/lamps.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  'on': false
+
+two:
+  'on': false

--- a/joel.williams/observer/test/fixtures/subscriptions.yml
+++ b/joel.williams/observer/test/fixtures/subscriptions.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  observerType: MyString
+  observerId: 1
+  subjectType: 
+  subsjectId: 1
+
+two:
+  observerType: MyString
+  observerId: 1
+  subjectType: 
+  subsjectId: 1

--- a/joel.williams/observer/test/fixtures/switches.yml
+++ b/joel.williams/observer/test/fixtures/switches.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  'on': false
+  type: 
+
+two:
+  'on': false
+  type: 

--- a/joel.williams/observer/test/models/lamp_test.rb
+++ b/joel.williams/observer/test/models/lamp_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LampTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/joel.williams/observer/test/models/subscription_test.rb
+++ b/joel.williams/observer/test/models/subscription_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SubscriptionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/joel.williams/observer/test/models/switch_test.rb
+++ b/joel.williams/observer/test/models/switch_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SwitchTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Note:  this can currently be run in a Rails Console - the flip() method is not currently switching that value, however queries are run and proper models are returned

Next steps are to get Pry going and debug that method, and I have a feeling that fixing the issue with default values in the migrations might resolve this issue as well.

That said, I wanted to push this up as it shows my reasoning and structure for this pattern.

Lamps are my Observer, and have the Update method (which in future iterations should belong to an inherited Observer class)
Switches are my Subject, and have a handful of methods that should belong to an inherited Subject class, plus overrides to call those methods

In both of these convert_to_model enables the use of String values to build active record (Rails' SQL wrapper) methods which allows Subscriptions (my model representing the Subject/Observer relationship) to be created between any two models.  The convert_to_model method should be moved to a helper and imported into classes (and would need to be updated when any Subject or Observer class is added)