### PR TITLE
clean up methods & verify working example

### DIFF
--- a/joel.williams/observer/app/models/lamp.rb
+++ b/joel.williams/observer/app/models/lamp.rb
@@ -1,5 +1,5 @@
 class Lamp < ApplicationRecord
-
+  # this is an Observer and should inherit certain methods/behaviors
   attribute :type, :string, default: "Lamp"
   attribute :on, :boolean, default: false
 
@@ -15,7 +15,9 @@ class Lamp < ApplicationRecord
     end
   end
 
-  def updateObserver(type, id)
+  # this belongs to an Observer
+  # "namespaced" to remove conflict between Active Record default update method
+  def observerUpdate(type, id)
     subject = self.convert_to_model(type).find(id)
     self.update on: subject.on
   end

--- a/joel.williams/observer/app/models/switch.rb
+++ b/joel.williams/observer/app/models/switch.rb
@@ -1,21 +1,11 @@
 class Switch < ApplicationRecord
-
+  # this is a Subject and should inherent certain methods/behaviors
   attribute :type, :string, default: "Switch"
   attribute :on, :boolean, default: false
 
-
-  def plug_in(observerType, observerId)
-    attach(observerType, observerId)
-  end
-
-  def unplug(observerType, observerId)
-    detach(observerType, observerId)
-  end
-
-
   def flip
     self.update on: !on
-    notify()
+    notifyObservers()
   end
 
   # TODO: dupe code - move to helper
@@ -30,9 +20,24 @@ class Switch < ApplicationRecord
     end
   end
 
-  # these methods belong to a Subject
-  # private
-    
+  # these belong to a Subject
+  def plug_in(observerType, observerId)
+    attach(observerType, observerId)
+  end
+
+  def unplug(observerType, observerId)
+    detach(observerType, observerId)
+  end
+  
+  private
+    def notifyObservers() 
+      Subscription.where(subjectId: self.id).each do | sub |
+        self.convert_to_model(sub.observerType)
+        .find(sub.observerId)
+        .observerUpdate(self.type, self.id)
+      end
+    end
+
     def attach(observerType, observerId)
       subscription = Subscription.create(observerType: observerType, observerId: observerId, subjectType: self.type, subjectId: self.id)
     end
@@ -41,14 +46,4 @@ class Switch < ApplicationRecord
       subscription = Subscription.find_by(observerType: observerType, observerId: observerId)
       Subscription.destroy(subscription.id)
     end
-
-    def notify() 
-      Subscription.where(subjectId: self.id).each do | sub |
-        self.convert_to_model(sub.observerType)
-        .find(sub.observerId)
-        .updateObserver(self.type, self.id)
-    end
-
-  end
-  
 end


### PR DESCRIPTION
did a little renaming for clarity & moved some things into private methods/added notes where inheritance could be used.

In contrast to what I said on my last PR, my Design Patterns book does specify that the Subject should be in charge of attaching/detaching Observers - so I'm following that here and leaving the "plug" methods on the Switch.